### PR TITLE
Float -> Int for Top-k

### DIFF
--- a/web.py
+++ b/web.py
@@ -7,7 +7,7 @@ app = FastAPI()
 class Input(BaseModel):
     generate_tokens_limit: int = 100
     top_p: float = 0.7
-    top_k: float = 0
+    top_k: int = 0
     temperature: float = 1.0
     text: str
 


### PR DESCRIPTION
Top-k should be a positive integer: 

```
Error: top_k has to be a strictly positive integer, but is 3.0
```

which cannot be fixed because it's a float in web.py.